### PR TITLE
Support dynamic resolution fallback for kernels that don't have all known types bound

### DIFF
--- a/Build/Projects/Protoinject.definition
+++ b/Build/Projects/Protoinject.definition
@@ -30,6 +30,7 @@
     <Compile Include="IConstructorArgument.cs" />
     <Compile Include="IContext.cs" />
     <Compile Include="ICurrentNode.cs" />
+    <Compile Include="IDynamicResolutionFallback.cs" />
     <Compile Include="IGenerateFactory.cs" />
     <Compile Include="IHierarchy.cs" />
     <Compile Include="IInjectionAttribute.cs" />

--- a/Protoinject/ActivationException.cs
+++ b/Protoinject/ActivationException.cs
@@ -1,10 +1,16 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Protoinject
 {
+    [Serializable]
     public class ActivationException : Exception
     {
         public ActivationException(string message, IPlan current) : base(message + " while underneath " + (current == null ? "<root>" : ("'" + current.FullName + "'")) + "")
+        {
+        }
+
+        public ActivationException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/Protoinject/IDynamicResolutionFallback.cs
+++ b/Protoinject/IDynamicResolutionFallback.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Protoinject
+{
+    public interface IDynamicResolutionFallback
+    {
+        object GetInstance(Type interfaceType);
+    }
+}

--- a/Protoinject/IKernel.cs
+++ b/Protoinject/IKernel.cs
@@ -10,6 +10,8 @@ namespace Protoinject
     public interface IKernel
     {
         IHierarchy Hierarchy { get; }
+        IDynamicResolutionFallback DynamicResolutionFallback { get; set; }
+
         IBindToInScopeWithDescendantFilterOrUniqueOrNamed<TInterface> Bind<TInterface>();
         IBindToInScopeWithDescendantFilterOrUniqueOrNamed Bind(Type @interface);
         void Unbind<T>();


### PR DESCRIPTION
This allows you to set up kernels which fall through to other or remote instances or resolution strategies.